### PR TITLE
fix: form-level error reporting

### DIFF
--- a/src/addons/formkit.ts
+++ b/src/addons/formkit.ts
@@ -28,15 +28,16 @@ export default <F extends RequestPayload>(initialFields?: F, formLevelErrorName?
       });
 
       on('error', (errors, node) => {
-        
+        const _formLevelErrorName = formLevelErrorName ? formLevelErrorName : node.name;
+
         /**
          * If one of the errors should be displayed at the form level, we extract
          * it from the errors object and set it as a form level error.
          */
         const formErrorMessages: string[] = [];
-        if (formLevelErrorName && formLevelErrorName in errors) {
-          formErrorMessages[0] = errors[formLevelErrorName];
-          delete errors[formLevelErrorName];
+        if (_formLevelErrorName in errors) {
+          formErrorMessages[0] = errors[_formLevelErrorName];
+          delete errors[_formLevelErrorName];
         }
 
         node.setErrors(formErrorMessages, errors);

--- a/src/addons/formkit.ts
+++ b/src/addons/formkit.ts
@@ -28,16 +28,18 @@ export default <F extends RequestPayload>(initialFields?: F, formLevelErrorName?
       });
 
       on('error', (errors, node) => {
-        const _formLevelErrorName = formLevelErrorName ? formLevelErrorName : node.name;
-
-        let formErrorMessages: string | undefined;
-        if (_formLevelErrorName in errors) {
-          formErrorMessages = errors[_formLevelErrorName];
-
-          delete errors[_formLevelErrorName];
+        
+        /**
+         * If one of the errors should be displayed at the form level, we extract
+         * it from the errors object and set it as a form level error.
+        */
+        const formErrorMessages: string[] = [];
+        if (formLevelErrorName && formLevelErrorName in errors) {
+          formErrorMessages[0] = errors[formLevelErrorName];
+          delete errors[formLevelErrorName];
         }
 
-        node.setErrors(_formLevelErrorName, errors);
+        node.setErrors(formErrorMessages, errors);
       });
 
       on('finish', (_, node) => {

--- a/src/addons/formkit.ts
+++ b/src/addons/formkit.ts
@@ -32,7 +32,7 @@ export default <F extends RequestPayload>(initialFields?: F, formLevelErrorName?
         /**
          * If one of the errors should be displayed at the form level, we extract
          * it from the errors object and set it as a form level error.
-        */
+         */
         const formErrorMessages: string[] = [];
         if (formLevelErrorName && formLevelErrorName in errors) {
           formErrorMessages[0] = errors[formLevelErrorName];


### PR DESCRIPTION
This PR fixes an issue where form-level errors were set to the node's name when `formLevelErrorName` was left unspecified.

Specifying `formLevelErrorName` will now correctly render a form-level error if an error with the key specified by `formLevelErrorName` exists in the response payload. Also, leaving `formLevelErrorName` unspecified will ensure no form-level errors are displayed. 

FYI @fenilli 